### PR TITLE
Add best_author method and support for Parsely/Sailthru tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,9 @@ page.title               # title of the page from the head section, as string
 page.best_title          # best title of the page, from a selection of candidates
 page.description         # returns the meta description
 page.best_description    # returns the first non-empty description between the following candidates: standard meta description, og:description, twitter:description, the first long paragraph
+page.author               # author of the page from the head section, as string
+page.best_author          # best author of the page, from a selection of candidates
+
 ```
 
 ### Links

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -45,7 +45,7 @@ module MetaInspector
 
     delegate [:content_type, :response]               => :@request
 
-    delegate [:parsed, :title, :best_title,
+    delegate [:parsed, :title, :best_title, :author, :best_author,
               :description, :best_description, :links,
               :images, :feed, :charset, :meta_tags,
               :meta_tag, :meta, :favicon,
@@ -58,6 +58,8 @@ module MetaInspector
         'scheme'           => scheme,
         'host'             => host,
         'root_url'         => root_url,
+        'author'            => author,
+        'best_author'      => best_author,
         'title'            => title,
         'best_title'       => best_title,
         'description'      => description,

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -26,7 +26,7 @@ module MetaInspector
     delegate [:head_links, :stylesheets, :canonicals, :feed]        => :@head_links_parser
     delegate [:links, :base_url]                                    => :@links_parser
     delegate :images                                                => :@images_parser
-    delegate [:title, :best_title, :description, :best_description] => :@texts_parser
+    delegate [:author, :best_author, :title, :best_title, :description, :best_description] => :@texts_parser
 
     # Returns the whole parsed document
     def parsed

--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -66,7 +66,6 @@ module MetaInspector
           meta['description'],
           meta['og:description'],
           meta['twitter:description'],
-          meta['parsely-description'],
           meta['sailthru.description'],
           secondary_description
         ]

--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -47,8 +47,8 @@ module MetaInspector
             parsed.css('body title'),
             meta['og:title'],
             parsed.css('h1').first,
-            meta['sailthru:title'],
             meta['parsely-title'],
+            meta['sailthru.title']
         ]
         candidates.flatten!
         candidates.compact!
@@ -66,8 +66,8 @@ module MetaInspector
           meta['description'],
           meta['og:description'],
           meta['twitter:description'],
-          meta['sailthru:description'],
           meta['parsely-description'],
+          meta['sailthru.description'],
           secondary_description
         ]
         candidates.find { |x| !x.to_s.empty? }
@@ -78,8 +78,8 @@ module MetaInspector
           meta['author'],
           meta['article:author'],
           meta['og:author'],
-          meta['sailthru:author'],
           meta['parsely-author'],
+          meta['sailthru.author']
         ]
 
         candidates.find { |x| !x.to_s.empty? }

--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -47,6 +47,8 @@ module MetaInspector
             parsed.css('body title'),
             meta['og:title'],
             parsed.css('h1').first,
+            meta['sailthru:title'],
+            meta['parsely-title'],
         ]
         candidates.flatten!
         candidates.compact!
@@ -64,6 +66,8 @@ module MetaInspector
           meta['description'],
           meta['og:description'],
           meta['twitter:description'],
+          meta['sailthru:description'],
+          meta['parsely-description'],
           secondary_description
         ]
         candidates.find { |x| !x.to_s.empty? }
@@ -74,6 +78,8 @@ module MetaInspector
           meta['author'],
           meta['article:author'],
           meta['og:author'],
+          meta['sailthru:author'],
+          meta['parsely-author'],
         ]
 
         candidates.find { |x| !x.to_s.empty? }

--- a/lib/meta_inspector/parsers/texts.rb
+++ b/lib/meta_inspector/parsers/texts.rb
@@ -29,6 +29,15 @@ module MetaInspector
         @best_description ||= find_best_description
       end
 
+
+      def author
+        @author ||= meta['author']
+      end
+
+      def best_author
+        @best_author ||= find_best_author
+      end
+
       private
 
       # Look for candidates and pick the longest one
@@ -37,7 +46,7 @@ module MetaInspector
             parsed.css('head title'),
             parsed.css('body title'),
             meta['og:title'],
-            parsed.css('h1').first
+            parsed.css('h1').first,
         ]
         candidates.flatten!
         candidates.compact!
@@ -57,6 +66,16 @@ module MetaInspector
           meta['twitter:description'],
           secondary_description
         ]
+        candidates.find { |x| !x.to_s.empty? }
+      end
+
+	    def find_best_author
+        candidates = [
+          meta['author'],
+          meta['article:author'],
+          meta['og:author'],
+        ]
+
         candidates.find { |x| !x.to_s.empty? }
       end
 

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -24,6 +24,8 @@ describe MetaInspector::Document do
                             "scheme"          => "http",
                             "host"            => "pagerankalert.com",
                             "root_url"        => "http://pagerankalert.com/",
+							              "author"		      => nil,
+							              "best_author"	    => nil,
                             "title"           => "PageRankAlert.com :: Track your PageRank changes & receive alerts",
                             "best_title"      => "PageRankAlert.com :: Track your PageRank changes & receive alerts",
                             "description"     => "Track your PageRank(TM) changes and receive alerts by email",


### PR DESCRIPTION
Hi @jaimeiniesta, I finally managed to get some time to work on the PRs for (#213 and #214). This PR adds the following -

1. Support for the `author` and `best_author` method.
2. Support for `parsely` and `sailthru` tags as fallbacks in determining `best_*` methods.

Let me know if this looks good!