### PR TITLE
Adds new "lazy_fetch" option and "inspect" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,6 +382,25 @@ cache = ActiveSupport::Cache.lookup_store(:file_store, '/tmp/cache')
 page = MetaInspector.new('http://example.com', faraday_http_cache: { store: cache })
 ```
 
+### Lazy fetch and inspecting before downloading (HEAD requests)
+
+By default MetaInspector will issue an HTTP `GET` request immediately.
+However, if you would like to issue an HTTP `HEAD` request first to inspect the response headers, you can use the `lazy_fetch: true` option like this:
+
+```ruby
+# set lazy_fetch: true to check the response if needed before downloading the entire body (or file)
+page = MetaInspector.new('http://example.com', lazy_fetch: true)
+response = page.inspect  # issues an HTTP HEAD request instead of a GET
+
+# check the response headers (e.g. if you only care about HTML files)
+#   response.headers["content-type"] == "text/html"
+puts "status: #{response.status}\nheaders: #{response.headers}"
+
+# calling any of the normal methods to access scraped data (e.g. page.links, page.images, etc)
+# will actually fetch the full response body
+puts "Internal URLs: #{page.links.internal.length}"  # issues an HTTP GET
+```
+
 ## Exception Handling
 
 Web page scraping is tricky, you can expect to find different exceptions during the request of the page or the parsing of its contents. MetaInspector will encapsulate these exceptions on these main errors:

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -47,7 +47,7 @@ module MetaInspector
     delegate [:url, :scheme, :host, :root_url,
               :tracked?, :untracked_url, :untrack!]   => :@url
 
-    delegate [:content_type, :response, :inspect]               => :@request
+    delegate [:content_type, :response, :head_response]  => :@request
 
     delegate [:parsed, :title, :best_title,
               :description, :best_description, :links,

--- a/lib/meta_inspector/parser.rb
+++ b/lib/meta_inspector/parser.rb
@@ -16,8 +16,9 @@ module MetaInspector
       @download_images = options[:download_images]
       @images_parser   = MetaInspector::Parsers::ImagesParser.new(self, download_images: @download_images)
       @texts_parser    = MetaInspector::Parsers::TextsParser.new(self)
+      @lazy            = options[:lazy] || false
 
-      parsed           # parse early so we can fail early
+      parsed unless @lazy
     end
 
     extend Forwardable

--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -46,7 +46,7 @@ module MetaInspector
       raise MetaInspector::RequestError.new(e)
     end
 
-    def inspect
+    def head_response
       fetch(verb: :head)
     rescue Faraday::TimeoutError => e
       raise MetaInspector::TimeoutError.new(e)

--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -63,7 +63,7 @@ module MetaInspector
         session = Faraday.new(@faraday_options) do |faraday|
           faraday.request :retry, max: @retries
 
-          faraday.use FaradayMiddleware::Gzip
+          faraday.use FaradayMiddleware::Gzip if verb == :get
 
           if @allow_redirections
             faraday.use FaradayMiddleware::FollowRedirects, limit: 10

--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -22,6 +22,7 @@ module MetaInspector
       @faraday_options    = options[:faraday_options] || {}
       @faraday_http_cache = options[:faraday_http_cache]
       @lazy               = options[:lazy] || false
+      @head_response      = nil
 
       response unless @lazy
     end
@@ -47,7 +48,7 @@ module MetaInspector
     end
 
     def head_response
-      fetch(verb: :head)
+      @head_response ||= fetch(verb: :head)
     rescue Faraday::TimeoutError => e
       raise MetaInspector::TimeoutError.new(e)
     rescue Faraday::Error::ConnectionFailed, Faraday::SSLError, URI::InvalidURIError, FaradayMiddleware::RedirectLimitReached => e

--- a/lib/meta_inspector/version.rb
+++ b/lib/meta_inspector/version.rb
@@ -1,3 +1,3 @@
 module MetaInspector
-  VERSION = '5.4.1'
+  VERSION = '5.4.1.1'
 end


### PR DESCRIPTION
Related to #221, my use case for this feature is if I discover a URL that points to a large file (like a video or a PDF) that I know I'm not going to scrape, then there's no need to issue the full HTTP GET request to download the entire thing, just to throw up a "non HTML content" error.

This gives us a point to inspect the server response headers (like Content-Type in this case) to make a decision if we still want to request the full body (or not).