### PR TITLE
Allow the use of a cache store to avoid network requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,6 +390,12 @@ cache = ActiveSupport::Cache.lookup_store(:file_store, '/tmp/cache')
 page = MetaInspector.new('http://example.com', faraday_http_cache: { store: cache })
 ```
 
+MetaInspector can also be used to cache network responses. For that you should pass the `cache_store` option. For example:
+
+ ```ruby
+page = MetaInspector.new('http://example.com', cache_store: { store: Rails.cache, expires_in: 1.hour })
+```
+
 ## Exception Handling
 
 Web page scraping is tricky, you can expect to find different exceptions during the request of the page or the parsing of its contents. MetaInspector will encapsulate these exceptions on these main errors:

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -29,6 +29,7 @@ module MetaInspector
       @normalize_url      = options[:normalize_url]
       @faraday_options    = options[:faraday_options]
       @faraday_http_cache = options[:faraday_http_cache]
+      @cache_store        = options[:cache_store]
       @url                = MetaInspector::URL.new(initial_url, normalize:          @normalize_url)
       @request            = MetaInspector::Request.new(@url,    allow_redirections: @allow_redirections,
                                                                 connection_timeout: @connection_timeout,
@@ -37,7 +38,8 @@ module MetaInspector
                                                                 encoding:           @encoding,
                                                                 headers:            @headers,
                                                                 faraday_options:    @faraday_options,
-                                                                faraday_http_cache: @faraday_http_cache) unless @document
+                                                                faraday_http_cache: @faraday_http_cache,
+                                                                cache_store:        @cache_store) unless @document
       @parser             = MetaInspector::Parser.new(self,     download_images:    @download_images)
     end
 

--- a/lib/meta_inspector/version.rb
+++ b/lib/meta_inspector/version.rb
@@ -1,3 +1,3 @@
 module MetaInspector
-  VERSION = '5.6.0'
+  VERSION = '5.6.1'
 end

--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = MetaInspector::VERSION
 
   gem.add_dependency 'nokogiri', '~> 1.8.5'
-  gem.add_dependency 'faraday', '~> 0.15.3'
+  gem.add_dependency 'faraday', '~> 0.17.3'
   gem.add_dependency 'faraday_middleware', '~> 0.12.2'
   gem.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   gem.add_dependency 'faraday-http-cache', '~> 2.0.0'


### PR DESCRIPTION
I had a use-case where it was helpful to avoid network requests and simply save the same response into a cache store (in my case it was redis) to improve the response time in the case that having some (potentially) stale data is acceptable.