### PR TITLE
added h1-h6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,12 @@ page.author              # author of the page from the meta author tag
 page.best_author         # best author of the page, from a selection of candidates
 page.description         # returns the meta description
 page.best_description    # returns the first non-empty description between the following candidates: standard meta description, og:description, twitter:description, the first long paragraph
+page.h1                  # returns h1 text array
+page.h2                  # returns h2 text array
+page.h3                  # returns h3 text array
+page.h4                  # returns h4 text array
+page.h5                  # returns h5 text array
+page.h6                  # returns h6 text array
 ```
 
 ### Links

--- a/README.md
+++ b/README.md
@@ -396,7 +396,8 @@ Web page scraping is tricky, you can expect to find different exceptions during 
 
 * `MetaInspector::TimeoutError`. When fetching a web page has taken too long.
 * `MetaInspector::RequestError`. When there has been an error on the request phase. Examples: page not found, SSL failure, invalid URI.
-* `MetaInspector::ParserError`. When there has been an error parsing the contents of the page. Example: trying to parse an image file.
+* `MetaInspector::ParserError`. When there has been an error parsing the contents of the page.
+* `MetaInspector::NonHtmlError`. When the contents of the page was not HTML. See also the `allow_non_html_content` option
 
 ## Examples
 

--- a/lib/meta_inspector/document.rb
+++ b/lib/meta_inspector/document.rb
@@ -105,7 +105,7 @@ module MetaInspector
 
     def document
       @document ||= if !allow_non_html_content && !content_type.nil? && content_type != 'text/html'
-        fail MetaInspector::ParserError.new "The url provided contains #{content_type} content instead of text/html content"
+        fail MetaInspector::NonHtmlError.new "The url provided contains #{content_type} content instead of text/html content"
       else
         @request.read
       end

--- a/lib/meta_inspector/errors.rb
+++ b/lib/meta_inspector/errors.rb
@@ -10,4 +10,6 @@ module MetaInspector
   class RequestError < Error; end
 
   class ParserError < Error; end
+
+  class NonHtmlError < ParserError; end
 end

--- a/lib/meta_inspector/parsers/images.rb
+++ b/lib/meta_inspector/parsers/images.rb
@@ -29,14 +29,16 @@ module MetaInspector
       # If none found, tries with Twitter image
       def owner_suggested
         suggested_img = content_of(meta['og:image']) || content_of(meta['twitter:image'])
-        URL.absolutify(suggested_img, base_url) if suggested_img
+        URL.absolutify(suggested_img, base_url, normalize: false) if suggested_img
       end
 
       # Returns an array of [img_url, width, height] sorted by image area (width * height)
       def with_size
         @with_size ||= begin
           img_nodes = parsed.search('//img').select{ |img_node| img_node['src'] }
-          imgs_with_size = img_nodes.map { |img_node| [URL.absolutify(img_node['src'], base_url), img_node['width'], img_node['height']] }
+          imgs_with_size = img_nodes.map do |img_node|
+            [URL.absolutify(img_node['src'], base_url, normalize: false), img_node['width'], img_node['height']]
+          end
           imgs_with_size.uniq! { |url, width, height| url }
           if @download_images
             imgs_with_size.map! do |url, width, height|
@@ -71,7 +73,7 @@ module MetaInspector
       def favicon
         query = '//link[@rel="icon" or contains(@rel, "shortcut")]'
         value = parsed.xpath(query)[0].attributes['href'].value
-        @favicon ||= URL.absolutify(value, base_url)
+        @favicon ||= URL.absolutify(value, base_url, normalize: false)
       rescue
         nil
       end
@@ -83,7 +85,7 @@ module MetaInspector
       end
 
       def absolutified_images
-        parsed_images.map { |i| URL.absolutify(i, base_url) }
+        parsed_images.map { |i| URL.absolutify(i, base_url, normalize: false) }
       end
 
       def parsed_images

--- a/lib/meta_inspector/url.rb
+++ b/lib/meta_inspector/url.rb
@@ -5,7 +5,7 @@ module MetaInspector
     attr_reader :url
 
     def initialize(initial_url, options = {})
-      options        = defaults.merge(options)
+      options        = self.class.defaults.merge(options)
 
       @normalize     = options[:normalize]
 
@@ -56,11 +56,13 @@ module MetaInspector
     #   http:, ftp:, telnet:, mailto:, javascript: ...
     # Protocol-relative URLs are also resolved to use the same
     # schema as the base_url
-    def self.absolutify(url, base_url)
+    def self.absolutify(url, base_url, options = {})
+      options = defaults.merge(options)
       if url =~ /^\w*\:/i
-        MetaInspector::URL.new(url).url
+        MetaInspector::URL.new(url, options).url
       else
-        Addressable::URI.join(base_url, url).normalize.to_s
+        uri = Addressable::URI.join(base_url, url)
+        options[:normalize] ? uri.normalize.to_s : uri.to_s
       end
     rescue MetaInspector::ParserError, Addressable::URI::InvalidURIError, ArgumentError
       nil
@@ -68,7 +70,7 @@ module MetaInspector
 
     private
 
-    def defaults
+    def self.defaults
       { :normalize => true }
     end
 

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -82,14 +82,14 @@ describe MetaInspector::Document do
       expect do
         image_url = MetaInspector::Document.new('http://pagerankalert.com/image.png')
         image_url.title
-      end.to raise_error(MetaInspector::ParserError)
+      end.to raise_error(MetaInspector::NonHtmlError)
     end
 
     it "should not allow non-html content type when explicitly disallowed" do
       expect do
         image_url = MetaInspector::Document.new('http://pagerankalert.com/image.png', allow_non_html_content: false)
         image_url.title
-      end.to raise_error(MetaInspector::ParserError)
+      end.to raise_error(MetaInspector::NonHtmlError)
     end
 
     it "should allow non-html content type when explicitly allowed" do

--- a/spec/fixtures/guardian.co.uk.response
+++ b/spec/fixtures/guardian.co.uk.response
@@ -57,7 +57,7 @@ Connection: keep-alive
         <meta property="og:title" content="More TechCrunch drama as Arrington-backed startup wins blog's contest"/>
         <meta property="og:type" content="article"/>
     <meta property="og:url" content="http://www.guardian.co.uk/media/pda/2011/sep/15/techcrunch-arrington-startups"/>
-            <meta property="og:image" content="https://static-secure.guim.co.uk/sys-images/Guardian/Pix/pictures/2011/8/8/1312810126887/gu_192x115.jpg"/>
+            <meta property="og:image" content="https://i.guim.co.uk/img/media/020bf03ae1d259626803b6c83ac57fd57382f285/0_102_5760_3456/master/5760.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&s=46e054247285bdf48a7621d371fc5070"/>
         <meta property="og:site_name" content="the Guardian"/>
     <meta property="fb:app_id" content="180444840287"/>
     <meta property="og:description" content="Despite claiming transparency, TechCrunch readers are not convinced that a 'Habbo Hotel for Facebook' was a deserving winner of a coveted award. By Jemima Kiss"/>

--- a/spec/meta_inspector/images_spec.rb
+++ b/spec/meta_inspector/images_spec.rb
@@ -126,6 +126,12 @@ describe MetaInspector do
 
       expect(page.images.owner_suggested).to be nil
     end
+
+    it "should not normalize image" do
+      page = MetaInspector.new("http://www.guardian.co.uk/media/pda/2011/sep/15/techcrunch-arrington-startups")
+
+      expect(page.images.owner_suggested).to eq("https://i.guim.co.uk/img/media/020bf03ae1d259626803b6c83ac57fd57382f285/0_102_5760_3456/master/5760.jpg?width=1200&height=630&quality=85&auto=format&fit=crop&overlay-align=bottom%2Cleft&overlay-width=100p&overlay-base64=L2ltZy9zdGF0aWMvb3ZlcmxheXMvdGctZGVmYXVsdC5wbmc&s=46e054247285bdf48a7621d371fc5070")
+    end
   end
 
   describe "images.with_size" do


### PR DESCRIPTION
I added h1-h6 support in the texts class. I plan on adding more methods related to the content of the page, and was wondering if this would be better all wrapped in a body or content class.

**Something like**
page.body.h1
page.content.h1

**instead of** 
page.h1
page.h2 
etc

Thoughts? I plan on adding a few other methods, like word_count.
