### PR TITLE
Upgrade to Faraday 1.0 / Issue #256

### DIFF
--- a/lib/meta_inspector/request.rb
+++ b/lib/meta_inspector/request.rb
@@ -48,7 +48,7 @@ module MetaInspector
       @response ||= fetch
     rescue Faraday::TimeoutError => e
       raise MetaInspector::TimeoutError.new(e)
-    rescue Faraday::Error::ConnectionFailed, Faraday::SSLError, URI::InvalidURIError, FaradayMiddleware::RedirectLimitReached => e
+    rescue Faraday::ConnectionFailed, Faraday::SSLError, URI::InvalidURIError, FaradayMiddleware::RedirectLimitReached => e
       raise MetaInspector::RequestError.new(e)
     end
 

--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -14,20 +14,20 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = MetaInspector::VERSION
 
-  gem.add_dependency 'nokogiri', '~> 1.10.7'
-  gem.add_dependency 'faraday', '~> 0.17.0'
-  gem.add_dependency 'faraday_middleware', '~> 0.13.1'
+  gem.add_dependency 'nokogiri', '~> 1.10.9'
+  gem.add_dependency 'faraday', '~> 1.0.0'
+  gem.add_dependency 'faraday_middleware', '~> 1.0.0'
   gem.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
-  gem.add_dependency 'faraday-http-cache', '~> 2.0.0'
+  gem.add_dependency 'faraday-http-cache', '~> 2.2.0'
   gem.add_dependency 'faraday-encoding', '~> 0.0.5'
   gem.add_dependency 'addressable', '~> 2.7.0'
   gem.add_dependency 'fastimage', '~> 2.1.7'
   gem.add_dependency 'nesty', '~> 1.0.2'
 
   gem.add_development_dependency 'rspec', '~> 3.9.0'
-  gem.add_development_dependency 'webmock', '~> 3.7.6'
+  gem.add_development_dependency 'webmock', '~> 3.8.3'
   gem.add_development_dependency 'awesome_print', '~> 1.8.0'
   gem.add_development_dependency 'rake', '~> 13.0.1'
-  gem.add_development_dependency 'pry', '~> 0.12.2'
-  gem.add_development_dependency 'rubocop', '~> 0.79.0'
+  gem.add_development_dependency 'pry', '~> 0.13.0'
+  gem.add_development_dependency 'rubocop', '~> 0.81.0'
 end


### PR DESCRIPTION
This PR upgrades Faraday to 1.0.0 and it's dependencies.
@jaimeiniesta maybe it's time for MetaInspector v6.0.0