### PR TITLE
Update faraday dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # MetaInpector Changelog
 
+## Unreleased
+
+* Upgrade to Faraday 1.1.
+
 ## [Changes in 5.10.1](https://github.com/jaimeiniesta/metainspector/compare/v5.10.0...v5.10.1)
 
 * Fix for empty base_href. Makes relative links work when base_href is nil but empty ("").

--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = MetaInspector::VERSION
 
   gem.add_dependency 'nokogiri', '~> 1.10.9'
-  gem.add_dependency 'faraday', '~> 1.0.0'
+  gem.add_dependency 'faraday', '~> 1.1.0'
   gem.add_dependency 'faraday_middleware', '~> 1.0.0'
   gem.add_dependency 'faraday-cookie_jar', '~> 0.0.6'
   gem.add_dependency 'faraday-http-cache', '~> 2.2.0'


### PR DESCRIPTION
## Why

In a project that depends both on `faraday` and `metainspector`, I get some warnings when trying to use "ruby 2.7.x", these warnings seemed to be fixed in the [latest version](https://github.com/lostisland/faraday/releases/tag/v1.1.0), but I cannot update `faraday` because of `metainspector`'s constraint:

```
$ bundle update faraday
Fetching gem metadata from https://rubygems.org/.......
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies............
Bundler could not find compatible versions for gem "faraday":
  In Gemfile:
    faraday (~> 1.1.0)

    metainspector was resolved to 5.10.1, which depends on
      faraday (~> 1.0.0)
```

## What

- Update the Faraday dependency. 
   - Should the constraint be loosen to `~ 1.0` instead? It seems the changes that could impact `lib/meta_inspector/request.rb` are unlikely to be done without a major release of `faraday`?
- Add a changelog entry (I this should be done separately, we can remove it from this PR)

If this PR can be reviewed/merged I would appreciate if you could also do a small release for this change 🙇 