### PR TITLE
Update Nokogiri dependency to fix security vulnerability.

### DIFF
--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = MetaInspector::VERSION
 
-  gem.add_dependency 'nokogiri', '~> 1.10.9'
+  gem.add_dependency 'nokogiri', '~> 1.11.0'
   gem.add_dependency 'faraday', '~> 1.1.0'
   gem.add_dependency 'faraday_middleware', '~> 1.0.0'
   gem.add_dependency 'faraday-cookie_jar', '~> 0.0.7'


### PR DESCRIPTION
+ Nokogiri 1.11.0 fixes security vulnerability [CVE-2020-26247](https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m)  
see their [CHANGELOG](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#v1110--2021-01-03)