### PR TITLE
update faraday requirement to be larger or equal to 1.1

### DIFF
--- a/meta_inspector.gemspec
+++ b/meta_inspector.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.version       = MetaInspector::VERSION
 
   gem.add_dependency 'nokogiri', '~> 1.11.0'
-  gem.add_dependency 'faraday', '~> 1.1.0'
+  gem.add_dependency 'faraday', '>= 1.1.0'
   gem.add_dependency 'faraday_middleware', '~> 1.0.0'
   gem.add_dependency 'faraday-cookie_jar', '~> 0.0.7'
   gem.add_dependency 'faraday-http-cache', '~> 2.2.0'


### PR DESCRIPTION
prevent metainspector from locking the version of faraday to 1.1.x